### PR TITLE
Issue 28: Make texts bold if `highlightedElement` is a col

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,13 +13,21 @@ const JSONGrid: React.FC<any> = ({
   theme = "default",
   customTheme = {},
 }) => {
-  const [highlightedElement, setHighlightedElement] = useState<HTMLElement | null>(null);
+  const [highlightedElement, setHighlightedElement] = useState<HTMLElement | HTMLElement[] | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (wrapperRef.current && !wrapperRef.current.contains(event.target as HTMLElement)) {
-        if (highlightedElement !== null) highlightedElement.classList.remove(styles.highlight);
+        if (highlightedElement !== null) {
+          if (Array.isArray(highlightedElement)) {
+            highlightedElement.forEach((element) => {
+              element.classList.remove(styles.highlight);
+            })
+          } else {
+            highlightedElement.classList.remove(styles.highlight);
+          }
+        }
         setHighlightedElement(null);
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,10 +40,10 @@ interface NestedGridProps {
   keyPath: keyPathNode[];
   dataKey?: string;
   data: JSONObject;
-  highlightedElement: HTMLElement | null;
+  highlightedElement: HTMLElement | HTMLElement[] | null;
   highlightSelected: boolean;
   onSelect: (keyPath: keyPathNode[]) => void;
-  setHighlightedElement: (element: HTMLElement | null) => void;
+  setHighlightedElement: (element: HTMLElement | HTMLElement[] | null) => void;
   defaultExpandDepth: number;
   defaultExpandKeyTree: JSONObject;
   searchText: string;


### PR DESCRIPTION
Fix #28

* Change the type of `highlightedElement`: from `HTMLElement | null` to `HTMLElement | HTMLElement[] | null`
* Change the type of `setHighlightedElement`: from `(element: HTMLElement | null) => void` to `(element: HTMLElement | HTMLElement[] | null) => void`
* Now the `highlightedElement` will be configured as a list of `HTMLElement<td>` instead of a `colgroup -> col`
* Remove the `<colgroup>` rendered in each table because it is no longer required.

Performance preview of this PR:

https://github.com/user-attachments/assets/b00a10ab-f186-4b86-ba9d-a44494f9e262

